### PR TITLE
generalise `map` to non-scalar functions

### DIFF
--- a/backend/src/tensorflow/compiler/xla/client/xla_builder.cpp
+++ b/backend/src/tensorflow/compiler/xla/client/xla_builder.cpp
@@ -171,13 +171,38 @@ extern "C" {
         return reinterpret_cast<XlaOp*>(new xla::XlaOp(res));
     }
 
+    XlaOp* DynamicUpdateSlice(
+        XlaOp& operand, XlaOp& update, XlaOp* start_indices, int start_indices_len
+    ) {
+        auto& operand_ = reinterpret_cast<xla::XlaOp&>(operand);
+        auto& update_ = reinterpret_cast<xla::XlaOp&>(update);
+        auto start_indices_ = reinterpret_cast<xla::XlaOp*>(start_indices);
+        auto start_indices_span = absl::Span<const xla::XlaOp>(start_indices_, start_indices_len);
+
+        xla::XlaOp res = xla::DynamicUpdateSlice(operand_, update_, start_indices_span);
+        return reinterpret_cast<XlaOp*>(new xla::XlaOp(res));
+    }
+
     XlaOp* ConcatInDim(XlaBuilder* builder, XlaOp* operands, int operands_len, int dimension) {
         auto builder_ = reinterpret_cast<xla::XlaBuilder*>(builder);
         auto operands_ = reinterpret_cast<xla::XlaOp*>(operands);
         auto operands_span = absl::Span<const xla::XlaOp>(operands_, operands_len);
 
         xla::XlaOp res = xla::ConcatInDim(builder_, operands_span, (int64_t) dimension);
+        return reinterpret_cast<XlaOp*>(new xla::XlaOp(res));
+    }
 
+    XlaOp* Tuple(XlaBuilder* builder, XlaOp* elements, int elements_len) {
+        auto builder_ = reinterpret_cast<xla::XlaBuilder*>(builder);
+        auto elements_ = reinterpret_cast<xla::XlaOp*>(elements);
+        auto elements_span = absl::Span<const xla::XlaOp>(elements_, elements_len);
+        xla::XlaOp res = xla::Tuple(builder_, elements_span);
+        return reinterpret_cast<XlaOp*>(new xla::XlaOp(res));
+    }
+
+    XlaOp* GetTupleElement(XlaOp& tuple_data, int index) {
+        auto& tuple_data_ = reinterpret_cast<xla::XlaOp&>(tuple_data);
+        xla::XlaOp res = xla::GetTupleElement(tuple_data_, (int64_t) index);
         return reinterpret_cast<XlaOp*>(new xla::XlaOp(res));
     }
 }
@@ -335,6 +360,15 @@ extern "C" {
         auto static_operands_span = absl::Span<const xla::XlaOp>(static_operands_, static_operands_len);
 
         xla::XlaOp res = xla::Map(builder_, operands_span, computation_, dimensions_span, static_operands_span);
+        return reinterpret_cast<XlaOp*>(new xla::XlaOp(res));
+    }
+
+    XlaOp* While(const XlaComputation& condition, const XlaComputation& body, XlaOp& init) {
+        auto& condition_ = reinterpret_cast<const xla::XlaComputation&>(condition);
+        auto& body_ = reinterpret_cast<const xla::XlaComputation&>(body);
+        auto& init_ = reinterpret_cast<xla::XlaOp&>(init);
+
+        xla::XlaOp res = xla::While(condition_, body_, init_);
         return reinterpret_cast<XlaOp*>(new xla::XlaOp(res));
     }
 }

--- a/backend/src/tensorflow/compiler/xla/client/xla_builder.h
+++ b/backend/src/tensorflow/compiler/xla/client/xla_builder.h
@@ -78,7 +78,13 @@ extern "C" {
         int strides_len
     );
 
+    XlaOp* DynamicUpdateSlice(
+        XlaOp& operand, XlaOp& update, XlaOp* start_indices, int start_indices_len
+    );
+
     XlaOp* ConcatInDim(XlaBuilder* builder, XlaOp* operands, int operands_len, int dimension);
+    XlaOp* Tuple(XlaBuilder* builder, XlaOp* elements, int elements_len);
+    XlaOp* GetTupleElement(XlaOp& tuple_data, int index);
 
     XlaOp* Eq(XlaOp& lhs, XlaOp& rhs);
     XlaOp* Ne(XlaOp& lhs, XlaOp& rhs);
@@ -139,4 +145,6 @@ extern "C" {
         XlaOp* static_operands,
         int static_operands_len
     );
+
+    XlaOp* While(const XlaComputation& condition, const XlaComputation& body, XlaOp& init);
 }

--- a/src/Tensor.idr
+++ b/src/Tensor.idr
@@ -467,6 +467,13 @@ map f (MkTensor {shape} mkOp) = MkTensor $ \builder => do
     )
   onCollectAny op XlaOp.delete
 
+map' : (Tensor from dtype -> Tensor to dtype)
+      -> Tensor (leading ++ from) dtype -> Tensor (leading ++ to) dtype
+map' f (MkTensor {shape=(leading ++ from)} mkOp) = MkTensor $ \builder => do
+  op <- mkOp builder
+  let MkTensor iteration = const 0
+  
+
 ||| Lift a binary function on scalars to an element-wise function on `Tensor`s of arbitrary shape.
 ||| For example,
 ||| ```idris

--- a/src/Tensor.idr
+++ b/src/Tensor.idr
@@ -469,6 +469,8 @@ mapScalar f (MkTensor {shape} mkOp) = MkTensor $ \builder => do
     )
   onCollectAny op XlaOp.delete
 
+-- we may be able to use map's ability to accept any number of arguments to avoid concatenating
+-- after mapping
 mapGeneral : (Primitive ft, Primitive tt) => {ts, leading : _} -> (Tensor fs ft -> Tensor ts tt)
              -> Tensor (leading ++ fs) ft -> Tensor (leading ++ ts) tt
 mapGeneral f {leading=[]} x = f x

--- a/src/Tensor.idr
+++ b/src/Tensor.idr
@@ -488,7 +488,7 @@ mapGeneral f {leading=(S k :: _)} x = concatRows (Prelude.map (mapGeneral f) (sp
 ||| `map diag x` is equivalent to `const [[0, 4, 8], [9, 13, 17]]`.
 |||
 ||| **Note:** This function is efficiently optimized for scalar-wise operations where `fs` and `ts`
-||| are `[]`. We cannot guarantee performance for other shapes.
+||| are `[]`. We do not guarantee performance for other shapes.
 export
 map : (Primitive ft, Primitive tt) => {fs, ts, leading : _} -> (Tensor fs ft -> Tensor ts tt)
       -> Tensor (leading ++ fs) ft -> Tensor (leading ++ ts) tt

--- a/src/XLA/Client/XlaBuilder.idr
+++ b/src/XLA/Client/XlaBuilder.idr
@@ -122,8 +122,20 @@ export
 prim__slice : GCAnyPtr -> GCPtr Int -> Int -> GCPtr Int -> Int -> GCPtr Int -> Int -> PrimIO AnyPtr
 
 export
+%foreign (libxla "DynamicUpdateSlice")
+prim__dynamicUpdateSlice : GCAnyPtr -> GCAnyPtr -> GCAnyPtr -> Int -> PrimIO AnyPtr
+
+export
 %foreign (libxla "ConcatInDim")
 prim__concatInDim : GCAnyPtr -> GCAnyPtr -> Int -> Int -> PrimIO AnyPtr
+
+export
+%foreign (libxla "Tuple")
+prim__tuple : GCAnyPtr -> GCAnyPtr -> Int -> PrimIO AnyPtr
+
+export
+%foreign (libxla "GetTupleElement")
+prim__getTupleElement : GCAnyPtr -> Int -> PrimIO AnyPtr
 
 export
 %foreign (libxla "Eq")
@@ -257,3 +269,7 @@ export
 %foreign (libxla "Map")
 prim__map : GCAnyPtr -> GCAnyPtr -> Int -> GCAnyPtr
             -> GCPtr Int -> Int -> AnyPtr -> Int -> PrimIO AnyPtr
+
+export
+%foreign (libxla "While")
+prim__while : GCAnyPtr -> GCAnyPtr -> GCAnyPtr -> PrimIO AnyPtr

--- a/test/Unit/TestTensor.idr
+++ b/test/Unit/TestTensor.idr
@@ -425,7 +425,8 @@ test_map = do
   sequence_ $ do
     x <- doubles
     let x = const {shape=[]} {dtype=F64} x
-    pure $ assertAll "map for F64 scalar" $ sufficientlyEq (map {leading=[]} (+ const 1.2) x) (x + const 1.2)
+    pure $ assertAll "map for F64 scalar" $
+      sufficientlyEq (map {leading=[]} (+ const 1.2) x) (x + const 1.2)
 
 export
 test_map2 : IO ()

--- a/test/Unit/TestTensor.idr
+++ b/test/Unit/TestTensor.idr
@@ -411,21 +411,21 @@ export
 test_map : IO ()
 test_map = do
   let x = const {shape=[_, _]} {dtype=S32} [[1, 15, 5], [-1, 7, 6]]
-  assertAll "map for S32 array" $ map abs x == abs x
+  assertAll "map for S32 array" $ map {leading=[_, _]} abs x == abs x
 
   let x = const {shape=[_, _]} {dtype=F64} [[1.0, 2.5, 0.0], [-0.8, -0.1, 5.0]]
   assertAll "map for F64 array" $
-    map (const 1 /) x == const [[1.0, 0.4, inf], [-1.25, -10, 0.2]]
+    map {leading=[_, _]} (const 1 /) x == const {shape=[_, _]} [[1.0, 0.4, inf], [-1.25, -10, 0.2]]
 
   sequence_ $ do
     x <- ints
     let x = const {shape=[]} {dtype=S32} x
-    pure $ assertAll "map for S32 scalar" $ map (+ const 1) x == x + const 1
+    pure $ assertAll "map for S32 scalar" $ map {leading=[]} (+ const 1) x == x + const 1
 
   sequence_ $ do
     x <- doubles
     let x = const {shape=[]} {dtype=F64} x
-    pure $ assertAll "map for F64 scalar" $ sufficientlyEq (map (+ const 1.2) x) (x + const 1.2)
+    pure $ assertAll "map for F64 scalar" $ sufficientlyEq (map {leading=[]} (+ const 1.2) x) (x + const 1.2)
 
 export
 test_map2 : IO ()


### PR DESCRIPTION
should we have separate functions for the element-wise and general cases?