### PR TITLE
[ compat ] adjust to upstream changes

### DIFF
--- a/src/Util.idr
+++ b/src/Util.idr
@@ -146,12 +146,6 @@ namespace List
   inBoundsCons _ InFirst = InFirst
   inBoundsCons (_ :: ys) (InLater prf) = InLater (inBoundsCons ys prf)
 
-||| Concatenate lists of proofs.
-public export
-(++) : All p xs -> All p ys -> All p (xs ++ ys)
-[] ++ pys = pys
-(px :: pxs) ++ pys = px :: (pxs ++ pys)
-
 ||| Apply a function to the environment of a reader.
 export
 (>$<) : (env' -> env) -> Reader env a -> Reader env' a


### PR DESCRIPTION
Spidr no longer builds against the latest Idris2 HEAD, because spidr has its own implementation of `(++)` for `Data.List.Quantifiers.All`, which has been added to base recently. This PR removes spidr's version of `(++)`, as it is no longer needed.