### PR TITLE
multiple return values - TensorList + PrimitiveRWList version

### DIFF
--- a/backend/src/tensorflow/compiler/xla/literal.cpp
+++ b/backend/src/tensorflow/compiler/xla/literal.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "literal.h"
 #include "shape.h"
+#include "shape_util.h"
 
 extern "C" {
     Literal* Literal_new(Shape& shape) {
@@ -31,61 +32,85 @@ extern "C" {
 }
 
 template <typename NativeT>
-NativeT Literal_Get(Literal& lit, int* indices) {
+NativeT Literal_Get(Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index) {
     xla::Literal& lit_ = reinterpret_cast<xla::Literal&>(lit);
-    int64_t rank = lit_.shape().rank();
-    int64_t multi_index[rank];
-    std::copy(indices, indices + rank, multi_index);
-    return lit_.Get<NativeT>(absl::Span<const int64_t>(multi_index, rank));
+    int64_t multi_index_[multi_index_len];
+    std::copy(multi_index, multi_index + multi_index_len, multi_index_);
+    auto multi_index_span = absl::Span<const int64_t>(multi_index_, multi_index_len);
+    auto& shape_index_ = reinterpret_cast<xla::ShapeIndex&>(shape_index);
+    return lit_.Get<NativeT>(multi_index_span, shape_index_);
 };
 
 template <typename NativeT>
-void Literal_Set(Literal& lit, int* indices, NativeT value) {
+void Literal_Set(
+    Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index, NativeT value)
+{
     xla::Literal& lit_ = reinterpret_cast<xla::Literal&>(lit);
-    int64_t rank = lit_.shape().rank();
-    int64_t multi_index[rank];
-    std::copy(indices, indices + rank, multi_index);
-    lit_.Set<NativeT>(absl::Span<const int64_t>(multi_index, rank), value);
+    int64_t multi_index_[multi_index_len];
+    std::copy(multi_index, multi_index + multi_index_len, multi_index_);
+    auto multi_index_span = absl::Span<const int64_t>(multi_index_, multi_index_len);
+    auto& shape_index_ = reinterpret_cast<xla::ShapeIndex&>(shape_index);
+    lit_.Set<NativeT>(multi_index_span, shape_index_, value);
 };
 
 extern "C" {
-    int Literal_Get_bool(Literal& lit, int* indices) {
-        return (int) Literal_Get<bool>(lit, indices);
+    int Literal_Get_bool(
+        Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index
+    ) {
+        return (int) Literal_Get<bool>(lit, multi_index, multi_index_len, shape_index);
     }
 
-    int Literal_Get_int32_t(Literal& lit, int* indices) {
-        return Literal_Get<int32_t>(lit, indices);
+    int Literal_Get_int32_t(
+        Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index
+    ) {
+        return Literal_Get<int32_t>(lit, multi_index, multi_index_len, shape_index);
     }
 
-    int Literal_Get_uint32_t(Literal& lit, int* indices) {
-        return (int) Literal_Get<uint32_t>(lit, indices);
+    int Literal_Get_uint32_t(
+        Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index
+    ) {
+        return (int) Literal_Get<uint32_t>(lit, multi_index, multi_index_len, shape_index);
     }
 
-    int Literal_Get_uint64_t(Literal& lit, int* indices) {
-        return (int) Literal_Get<uint64_t>(lit, indices);
+    int Literal_Get_uint64_t(
+        Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index
+    ) {
+        return (int) Literal_Get<uint64_t>(lit, multi_index, multi_index_len, shape_index);
     }
 
-    double Literal_Get_double(Literal& lit, int* indices) {
-        return Literal_Get<double>(lit, indices);
+    double Literal_Get_double(
+        Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index
+    ) {
+        return Literal_Get<double>(lit, multi_index, multi_index_len, shape_index);
     }
 
-    void Literal_Set_bool(Literal& lit, int* indices, int value) {
-        Literal_Set<bool>(lit, indices, (bool) value);
+    void Literal_Set_bool(
+        Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index, int value
+    ) {
+        Literal_Set<bool>(lit, multi_index, multi_index_len, shape_index, (bool) value);
     }
 
-    void Literal_Set_int32_t(Literal& lit, int* indices, int value) {
-        Literal_Set<int32_t>(lit, indices, value);
+    void Literal_Set_int32_t(
+        Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index, int value
+    ) {
+        Literal_Set<int32_t>(lit, multi_index, multi_index_len, shape_index, value);
     }
 
-    void Literal_Set_uint32_t(Literal& lit, int* indices, int value) {
-        Literal_Set<uint32_t>(lit, indices, (uint32_t) value);
+    void Literal_Set_uint32_t(
+        Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index, int value
+    ) {
+        Literal_Set<uint32_t>(lit, multi_index, multi_index_len, shape_index, (uint32_t) value);
     }
 
-    void Literal_Set_uint64_t(Literal& lit, int* indices, int value) {
-        Literal_Set<uint64_t>(lit, indices, (uint64_t) value);
+    void Literal_Set_uint64_t(
+        Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index, int value
+    ) {
+        Literal_Set<uint64_t>(lit, multi_index, multi_index_len, shape_index, (uint64_t) value);
     }
 
-    void Literal_Set_double(Literal& lit, int* indices, double value) {
-        Literal_Set<double>(lit, indices, value);
+    void Literal_Set_double(
+        Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index, double value
+    ) {
+        Literal_Set<double>(lit, multi_index, multi_index_len, shape_index, value);
     }
 }

--- a/backend/src/tensorflow/compiler/xla/literal.h
+++ b/backend/src/tensorflow/compiler/xla/literal.h
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include "shape.h"
+#include "shape_util.h"
 
 extern "C" {
     struct Literal;
@@ -22,11 +23,11 @@ extern "C" {
 
     void Literal_delete(Literal* lit);
 
-    int Literal_Get_bool(Literal& lit, int* indices);
-    int Literal_Get_int(Literal& lit, int* indices);
-    double Literal_Get_double(Literal& lit, int* indices);
+    int Literal_Get_bool(Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index);
+    int Literal_Get_int(Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index);
+    double Literal_Get_double(Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index);
 
-    void Literal_Set_bool(Literal& lit, int* indices, int value);
-    void Literal_Set_int(Literal& lit, int* indices, int value);
-    void Literal_Set_double(Literal& lit, int* indices, double value);
+    void Literal_Set_bool(Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index, int value);
+    void Literal_Set_int(Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index, int value);
+    void Literal_Set_double(Literal& lit, int* multi_index, int multi_index_len, ShapeIndex& shape_index, double value);
 }

--- a/backend/src/tensorflow/compiler/xla/shape_util.cpp
+++ b/backend/src/tensorflow/compiler/xla/shape_util.cpp
@@ -17,8 +17,24 @@ limitations under the License.
 #include "tensorflow/compiler/xla/shape_util.h"
 
 #include "shape.h"
+#include "shape_util.h"
 
 extern "C" {
+    ShapeIndex* ShapeIndex_new() {
+        return reinterpret_cast<ShapeIndex*>(new xla::ShapeIndex());
+    }
+    void ShapeIndex_delete(ShapeIndex* s) {
+        delete reinterpret_cast<xla::ShapeIndex*>(s);
+    }
+
+    void ShapeIndex_push_back(ShapeIndex& shape_index, int value) {
+        reinterpret_cast<xla::ShapeIndex&>(shape_index).push_back(value);
+    }
+
+    void ShapeIndex_push_front(ShapeIndex& shape_index, int value) {
+        reinterpret_cast<xla::ShapeIndex&>(shape_index).push_front(value);
+    }
+
     Shape* MakeShape(int primitive_type, int* shape, int rank) {
         int64_t shape64[rank];
         std::copy(shape, shape + rank, shape64);

--- a/backend/src/tensorflow/compiler/xla/shape_util.h
+++ b/backend/src/tensorflow/compiler/xla/shape_util.h
@@ -16,5 +16,12 @@ limitations under the License.
 #include "shape.h"
 
 extern "C" {
+    struct ShapeIndex;
+
+    ShapeIndex* ShapeIndex_new();
+    void ShapeIndex_delete(ShapeIndex* s);
+    void ShapeIndex_push_back(ShapeIndex& shape_index, int value);
+    void ShapeIndex_push_front(ShapeIndex& shape_index, int value);
+
     Shape* MakeShape(int primitive_type, int* shape, int rank);
 }

--- a/src/Compiler/Eval.idr
+++ b/src/Compiler/Eval.idr
@@ -249,25 +249,18 @@ execute f = do
   lit <- exec f
   pure (read {dtype} lit)
 
-namespace PrimitiveRWVect
-  public export
-  data PrimitiveRWVect : Vect n (Types.Shape #: Type #: Type) -> Type where
-    Nil : PrimitiveRWVect []
-    (::) : PrimitiveRW dtype ty ->
-           PrimitiveRWVect stt ->
-           PrimitiveRWVect ((shape ##:: dtype ##:: ty) :: stt)
-
-  export
-  toLiteralRWVect : PrimitiveRWVect shapes -> LiteralRWVect shapes
-  toLiteralRWVect [] = []
-  toLiteralRWVect ((::) p {dtype} {ty} ps) = ((::) (literalRW p) {dtype} {ty} (toLiteralRWVect ps))
-    where
-    literalRW : PrimitiveRW dtype ty -> LiteralRW dtype ty
-    -- literalRW _ = %search
-
 namespace Tuple
   export covering
   execute : {shapes : _} -> PrimitiveRWVect shapes => Fn 0 -> ErrIO $ LiteralVect shapes
   execute @{ps} f = do
     lit <- exec f
     pure (read @{toLiteralRWVect ps} {shapes} lit)
+
+    where
+
+    toLiteralRWVect : PrimitiveRWVect s -> LiteralRWVect s
+    toLiteralRWVect [] = []
+    toLiteralRWVect ((::) p {dtype} {ty} ps) = ((::) (literalRW p) {dtype} {ty} (toLiteralRWVect ps))
+      where
+      literalRW : PrimitiveRW dtype ty -> LiteralRW dtype ty
+      literalRW p = believe_me p

--- a/src/Compiler/Eval.idr
+++ b/src/Compiler/Eval.idr
@@ -245,16 +245,12 @@ exec f = do
 
 export covering
 execute : PrimitiveRW dtype a => Fn 0 -> {shape : _} -> ErrIO $ Literal shape a
-execute f = do
-  lit <- exec f
-  pure (read {dtype} lit)
+execute f = read {dtype} !(exec f)
 
 namespace Tuple
   export covering
   execute : {shapes : _} -> PrimitiveRWVect shapes => Fn 0 -> ErrIO $ LiteralVect shapes
-  execute @{ps} f = do
-    lit <- exec f
-    pure (read @{toLiteralRWVect ps} {shapes} lit)
+  execute @{ps} f = read @{%search} @{toLiteralRWVect ps} {shapes} !(exec f)
 
     where
 

--- a/src/Compiler/LiteralRW.idr
+++ b/src/Compiler/LiteralRW.idr
@@ -79,3 +79,34 @@ export
 LiteralRW U64 Nat where
   set = UInt64t.set
   get = UInt64t.get
+
+infixr 9 #:, ##::
+
+public export
+record (#:) a b where
+  constructor (##::)
+  fst : a
+  0 snd : b
+
+namespace LiteralRWVect
+  public export
+  data LiteralRWVect : Vect n (Shape #: Type #: Type) -> Type where
+    Nil : LiteralRWVect []
+    (::) : LiteralRW dtype ty ->
+           LiteralRWVect stt ->
+           LiteralRWVect ((shape ##:: dtype ##:: ty) :: stt)
+
+namespace LiteralVect
+  public export
+  data LiteralVect : Vect n (Types.Shape #: Type #: Type) -> Type where
+    Nil : LiteralVect []
+    (::) : Literal shape ty ->
+           LiteralVect stt ->
+           LiteralVect ((shape ##:: dtype ##:: ty) :: stt)
+
+namespace Tuple
+  export
+  read : {shapes : _} -> LiteralRWVect shapes => Literal -> LiteralVect shapes
+  read {shapes = []} @{[]} lit = []
+  read {shapes = ((shape ##:: dtype ##:: _) :: ss)} @{(p :: ps)} lit =
+    map (get {dtype} lit) indexed :: read {shapes = ss} @{ps} lit

--- a/src/Compiler/LiteralRW.idr
+++ b/src/Compiler/LiteralRW.idr
@@ -39,7 +39,7 @@ indexed = go shape []
   go (0 :: _) _ = []
   go (S d :: ds) idxs = concat $ map (\i => go ds (snoc idxs i)) (range (S d))
 
-export
+public export
 interface Primitive dtype => LiteralRW dtype ty where
   set : Literal -> List Nat -> ty -> IO ()
   get : Literal -> List Nat -> ty
@@ -80,14 +80,6 @@ LiteralRW U64 Nat where
   set = UInt64t.set
   get = UInt64t.get
 
-infixr 9 #:, ##::
-
-public export
-record (#:) a b where
-  constructor (##::)
-  fst : a
-  0 snd : b
-
 namespace LiteralRWVect
   public export
   data LiteralRWVect : Vect n (Shape #: Type #: Type) -> Type where
@@ -95,14 +87,6 @@ namespace LiteralRWVect
     (::) : LiteralRW dtype ty ->
            LiteralRWVect stt ->
            LiteralRWVect ((shape ##:: dtype ##:: ty) :: stt)
-
-namespace LiteralVect
-  public export
-  data LiteralVect : Vect n (Types.Shape #: Type #: Type) -> Type where
-    Nil : LiteralVect []
-    (::) : Literal shape ty ->
-           LiteralVect stt ->
-           LiteralVect ((shape ##:: dtype ##:: ty) :: stt)
 
 namespace Tuple
   export

--- a/src/Compiler/Xla/Prim/TensorFlow/Compiler/Xla/Literal.idr
+++ b/src/Compiler/Xla/Prim/TensorFlow/Compiler/Xla/Literal.idr
@@ -29,40 +29,40 @@ prim__delete : AnyPtr -> PrimIO ()
 
 export
 %foreign (libxla "Literal_Set_bool")
-prim__literalSetBool : GCAnyPtr -> GCPtr Int -> Int -> PrimIO ()
+prim__literalSetBool : GCAnyPtr -> GCPtr Int -> Int -> GCAnyPtr -> Int -> PrimIO ()
 
 export
 %foreign (libxla "Literal_Get_bool")
-literalGetBool : GCAnyPtr -> GCPtr Int -> Int
+literalGetBool : GCAnyPtr -> GCPtr Int -> Int -> GCAnyPtr -> Int
 
 export
 %foreign (libxla "Literal_Set_double")
-prim__literalSetDouble : GCAnyPtr -> GCPtr Int -> Double -> PrimIO ()
+prim__literalSetDouble : GCAnyPtr -> GCPtr Int -> Int -> GCAnyPtr -> Double -> PrimIO ()
 
 export
 %foreign (libxla "Literal_Get_double")
-literalGetDouble : GCAnyPtr -> GCPtr Int -> Double
+literalGetDouble : GCAnyPtr -> GCPtr Int -> Int -> GCAnyPtr -> Double
 
 export
 %foreign (libxla "Literal_Set_int32_t")
-prim__literalSetInt32t : GCAnyPtr -> GCPtr Int -> Int -> PrimIO ()
+prim__literalSetInt32t : GCAnyPtr -> GCPtr Int -> Int -> GCAnyPtr -> Int -> PrimIO ()
 
 export
 %foreign (libxla "Literal_Get_int32_t")
-literalGetInt32t : GCAnyPtr -> GCPtr Int -> Int
+literalGetInt32t : GCAnyPtr -> GCPtr Int -> Int -> GCAnyPtr -> Int
 
 export
 %foreign (libxla "Literal_Set_uint32_t")
-prim__literalSetUInt32t : GCAnyPtr -> GCPtr Int -> Bits32 -> PrimIO ()
+prim__literalSetUInt32t : GCAnyPtr -> GCPtr Int -> Int -> GCAnyPtr -> Bits32 -> PrimIO ()
 
 export
 %foreign (libxla "Literal_Get_uint32_t")
-literalGetUInt32t : GCAnyPtr -> GCPtr Int -> Bits32
+literalGetUInt32t : GCAnyPtr -> GCPtr Int -> Int -> GCAnyPtr -> Bits32
 
 export
 %foreign (libxla "Literal_Set_uint64_t")
-prim__literalSetUInt64t : GCAnyPtr -> GCPtr Int -> Bits64 -> PrimIO ()
+prim__literalSetUInt64t : GCAnyPtr -> GCPtr Int -> Int -> GCAnyPtr -> Bits64 -> PrimIO ()
 
 export
 %foreign (libxla "Literal_Get_uint64_t")
-literalGetUInt64t : GCAnyPtr -> GCPtr Int -> Bits64
+literalGetUInt64t : GCAnyPtr -> GCPtr Int -> Int -> GCAnyPtr -> Bits64

--- a/src/Compiler/Xla/Prim/TensorFlow/Compiler/Xla/ShapeUtil.idr
+++ b/src/Compiler/Xla/Prim/TensorFlow/Compiler/Xla/ShapeUtil.idr
@@ -20,5 +20,21 @@ import System.FFI
 import Compiler.Xla.Prim.Util
 
 export
+%foreign (libxla "ShapeIndex_new")
+prim__shapeIndexNew : PrimIO AnyPtr
+
+export
+%foreign (libxla "ShapeIndex_delete")
+prim__shapeIndexDelete : AnyPtr -> PrimIO ()
+
+export
+%foreign (libxla "ShapeIndex_push_back")
+prim__shapeIndexPushBack : GCAnyPtr -> Int -> PrimIO ()
+
+export
+%foreign (libxla "ShapeIndex_push_front")
+prim__shapeIndexPushFront : GCAnyPtr -> Int -> PrimIO ()
+
+export
 %foreign (libxla "MakeShape")
 prim__mkShape : Int -> GCPtr Int -> Int -> PrimIO AnyPtr

--- a/src/Compiler/Xla/TensorFlow/Compiler/Xla/Literal.idr
+++ b/src/Compiler/Xla/TensorFlow/Compiler/Xla/Literal.idr
@@ -41,65 +41,65 @@ allocLiteral shape = do
 
 namespace Bool
   export
-  set : Literal -> List Nat -> Bool -> IO ()
-  set (MkLiteral lit) idxs value = do
+  set : Literal -> List Nat -> ShapeIndex -> Bool -> IO ()
+  set (MkLiteral lit) idxs (MkShapeIndex shapeIndex) value = do
     MkIntArray idxsArrayPtr <- mkIntArray idxs
-    primIO $ prim__literalSetBool lit idxsArrayPtr (if value then 1 else 0)
+    primIO $ prim__literalSetBool lit idxsArrayPtr (cast $ length idxs) shapeIndex (if value then 1 else 0)
 
   export
-  get : Literal -> List Nat -> Bool
-  get (MkLiteral lit) idxs = unsafePerformIO $ do
+  get : Literal -> List Nat -> ShapeIndex -> Bool
+  get (MkLiteral lit) idxs (MkShapeIndex shapeIndex) = unsafePerformIO $ do
     MkIntArray idxsArrayPtr <- mkIntArray idxs
-    pure $ cIntToBool $ literalGetBool lit idxsArrayPtr
+    pure $ cIntToBool $ literalGetBool lit idxsArrayPtr (cast $ length idxs) shapeIndex
 
 namespace Double
   export
-  set : Literal -> List Nat -> Double -> IO ()
-  set (MkLiteral lit) idxs value = do
+  set : Literal -> List Nat -> ShapeIndex -> Double -> IO ()
+  set (MkLiteral lit) idxs (MkShapeIndex shapeIndex) value = do
     MkIntArray idxsArrayPtr <- mkIntArray idxs
-    primIO $ prim__literalSetDouble lit idxsArrayPtr value
+    primIO $ prim__literalSetDouble lit idxsArrayPtr (cast $ length idxs) shapeIndex value
 
   export
-  get : Literal -> List Nat -> Double
-  get (MkLiteral lit) idxs = unsafePerformIO $ do
+  get : Literal -> List Nat -> ShapeIndex -> Double
+  get (MkLiteral lit) idxs (MkShapeIndex shapeIndex) = unsafePerformIO $ do
     MkIntArray idxsArrayPtr <- mkIntArray idxs
-    pure $ literalGetDouble lit idxsArrayPtr
+    pure $ literalGetDouble lit idxsArrayPtr (cast $ length idxs) shapeIndex
 
 namespace Int32t
   export
-  set : Literal -> List Nat -> Int32 -> IO ()
-  set (MkLiteral lit) idxs value = do
+  set : Literal -> List Nat -> ShapeIndex -> Int32 -> IO ()
+  set (MkLiteral lit) idxs (MkShapeIndex shapeIndex) value = do
     MkIntArray idxsArrayPtr <- mkIntArray idxs
-    primIO $ prim__literalSetInt32t lit idxsArrayPtr (cast value)
+    primIO $ prim__literalSetInt32t lit idxsArrayPtr (cast $ length idxs) shapeIndex (cast value)
 
   export
-  get : Literal -> List Nat -> Int32
-  get (MkLiteral lit) idxs = unsafePerformIO $ do
+  get : Literal -> List Nat -> ShapeIndex -> Int32
+  get (MkLiteral lit) idxs (MkShapeIndex shapeIndex) = unsafePerformIO $ do
     MkIntArray idxsArrayPtr <- mkIntArray idxs
-    pure $ cast $ literalGetInt32t lit idxsArrayPtr
+    pure $ cast $ literalGetInt32t lit idxsArrayPtr (cast $ length idxs) shapeIndex
 
 namespace UInt32t
   export
-  set : Literal -> List Nat -> Nat -> IO ()
-  set (MkLiteral lit) idxs value = do
+  set : Literal -> List Nat -> ShapeIndex -> Nat -> IO ()
+  set (MkLiteral lit) idxs (MkShapeIndex shapeIndex) value = do
     MkIntArray idxsArrayPtr <- mkIntArray idxs
-    primIO $ prim__literalSetUInt32t lit idxsArrayPtr (cast value)
+    primIO $ prim__literalSetUInt32t lit idxsArrayPtr (cast $ length idxs) shapeIndex (cast value)
 
   export
-  get : Literal -> List Nat -> Nat
-  get (MkLiteral lit) idxs = unsafePerformIO $ do
+  get : Literal -> List Nat -> ShapeIndex -> Nat
+  get (MkLiteral lit) idxs (MkShapeIndex shapeIndex) = unsafePerformIO $ do
     MkIntArray idxsArrayPtr <- mkIntArray idxs
-    pure $ cast $ literalGetUInt32t lit idxsArrayPtr
+    pure $ cast $ literalGetUInt32t lit idxsArrayPtr (cast $ length idxs) shapeIndex
 
 namespace UInt64t
   export
-  set : Literal -> List Nat -> Nat -> IO ()
-  set (MkLiteral lit) idxs value = do
+  set : Literal -> List Nat -> ShapeIndex -> Nat -> IO ()
+  set (MkLiteral lit) idxs (MkShapeIndex shapeIndex) value = do
     MkIntArray idxsArrayPtr <- mkIntArray idxs
-    primIO $ prim__literalSetUInt64t lit idxsArrayPtr (cast value)
+    primIO $ prim__literalSetUInt64t lit idxsArrayPtr (cast $ length idxs) shapeIndex (cast value)
 
   export
-  get : Literal -> List Nat -> Nat
-  get (MkLiteral lit) idxs = unsafePerformIO $ do
+  get : Literal -> List Nat -> ShapeIndex -> Nat
+  get (MkLiteral lit) idxs (MkShapeIndex shapeIndex) = unsafePerformIO $ do
     MkIntArray idxsArrayPtr <- mkIntArray idxs
-    pure $ cast $ literalGetUInt64t lit idxsArrayPtr
+    pure $ cast $ literalGetUInt64t lit idxsArrayPtr (cast $ length idxs) shapeIndex

--- a/src/Compiler/Xla/TensorFlow/Compiler/Xla/ShapeUtil.idr
+++ b/src/Compiler/Xla/TensorFlow/Compiler/Xla/ShapeUtil.idr
@@ -21,6 +21,32 @@ import Compiler.Xla.TensorFlow.Compiler.Xla.XlaData
 import Compiler.Xla.Util
 import Types
 
+public export
+data ShapeIndex : Type where
+  MkShapeIndex : GCAnyPtr -> ShapeIndex
+
+namespace ShapeIndex
+  export
+  delete : HasIO io => AnyPtr -> io ()
+  delete = primIO . prim__shapeIndexDelete
+
+export
+allocShapeIndex : HasIO io => io ShapeIndex
+allocShapeIndex = do
+  ptr <- primIO prim__shapeIndexNew
+  ptr <- onCollectAny ptr ShapeIndex.delete
+  pure (MkShapeIndex ptr)
+
+export
+pushBack : HasIO io => ShapeIndex -> Nat -> io ()
+pushBack (MkShapeIndex shapeIndex) value =
+  primIO $ prim__shapeIndexPushBack shapeIndex (cast value)
+
+export
+pushFront : HasIO io => ShapeIndex -> Nat -> io ()
+pushFront (MkShapeIndex shapeIndex) value =
+  primIO $ prim__shapeIndexPushFront shapeIndex (cast value)
+
 export
 mkShape : (HasIO io, Primitive dtype) => Types.Shape -> io Xla.Shape
 mkShape shape = do

--- a/src/Compiler/Xla/TensorFlow/Compiler/Xla/XlaData.idr
+++ b/src/Compiler/Xla/TensorFlow/Compiler/Xla/XlaData.idr
@@ -81,20 +81,20 @@ allocDotDimensionNumbers = do
 
 export
 addLhsContractingDimensions : HasIO io => DotDimensionNumbers -> Nat -> io ()
-addLhsContractingDimensions (MkDotDimensionNumbers dimension_numbers) n =
-  primIO $ prim__addLhsContractingDimensions dimension_numbers (cast n)
+addLhsContractingDimensions (MkDotDimensionNumbers dimensionNumbers) n =
+  primIO $ prim__addLhsContractingDimensions dimensionNumbers (cast n)
 
 export
 addRhsContractingDimensions : HasIO io => DotDimensionNumbers -> Nat -> io ()
-addRhsContractingDimensions (MkDotDimensionNumbers dimension_numbers) n =
-  primIO $ prim__addRhsContractingDimensions dimension_numbers (cast n)
+addRhsContractingDimensions (MkDotDimensionNumbers dimensionNumbers) n =
+  primIO $ prim__addRhsContractingDimensions dimensionNumbers (cast n)
 
 export
 addLhsBatchDimensions : HasIO io => DotDimensionNumbers -> Nat -> io ()
-addLhsBatchDimensions (MkDotDimensionNumbers dimension_numbers) n =
-  primIO $ prim__addLhsBatchDimensions dimension_numbers (cast n)
+addLhsBatchDimensions (MkDotDimensionNumbers dimensionNumbers) n =
+  primIO $ prim__addLhsBatchDimensions dimensionNumbers (cast n)
 
 export
 addRhsBatchDimensions : HasIO io => DotDimensionNumbers -> Nat -> io ()
-addRhsBatchDimensions (MkDotDimensionNumbers dimension_numbers) n =
-  primIO $ prim__addRhsBatchDimensions dimension_numbers (cast n)
+addRhsBatchDimensions (MkDotDimensionNumbers dimensionNumbers) n =
+  primIO $ prim__addRhsBatchDimensions dimensionNumbers (cast n)

--- a/src/Literal.idr
+++ b/src/Literal.idr
@@ -28,6 +28,7 @@ limitations under the License.
 module Literal
 
 import public Types
+import Util
 
 ||| A scalar or array of values.
 public export
@@ -210,3 +211,11 @@ namespace All
     Scalar : forall x . p x -> All p (Scalar x)
     Nil  : All p []
     (::) : All p x -> All p xs -> All p (x :: xs)
+
+namespace LiteralVect
+  public export
+  data LiteralVect : Vect n (Shape #: Type #: Type) -> Type where
+    Nil : LiteralVect []
+    (::) : Literal shape ty ->
+           LiteralVect stt ->
+           LiteralVect ((shape ##:: dtype ##:: ty) :: stt)

--- a/src/Primitive.idr
+++ b/src/Primitive.idr
@@ -23,6 +23,8 @@ module Primitive
 
 import Compiler.LiteralRW
 import public Compiler.Xla.TensorFlow.Compiler.Xla.XlaData
+import Types
+import Util
 
 %hide Prelude.Num
 %hide Prelude.Neg
@@ -92,3 +94,10 @@ export PrimitiveRW S32 Int32 where
 export PrimitiveRW U32 Nat where
 export PrimitiveRW U64 Nat where
 export PrimitiveRW F64 Double where
+
+public export
+data PrimitiveRWVect : Vect n (Shape #: Type #: Type) -> Type where
+  Nil : PrimitiveRWVect []
+  (::) : PrimitiveRW dtype ty ->
+         PrimitiveRWVect stt ->
+         PrimitiveRWVect ((shape ##:: dtype ##:: ty) :: stt)

--- a/src/Tensor.idr
+++ b/src/Tensor.idr
@@ -96,7 +96,7 @@ namespace S32
   fromInteger : Integer -> Graph $ Tensor [] S32
   fromInteger = tensor . Scalar . fromInteger
 
-namespace TensorList
+namespace TensorVect
   public export
   data TensorVect : Vect n (Shape #: Type #: Type) -> Type where
     Nil : TensorVect []

--- a/src/Util.idr
+++ b/src/Util.idr
@@ -150,3 +150,11 @@ namespace List
 export
 (>$<) : (env' -> env) -> Reader env a -> Reader env' a
 f >$< (MkReaderT g) = MkReaderT (g . f)
+
+infixr 9 #:, ##::
+
+public export
+record (#:) a b where
+  constructor (##::)
+  fst : a
+  0 snd : b

--- a/test/Unit/TestTensor.idr
+++ b/test/Unit/TestTensor.idr
@@ -68,16 +68,16 @@ evalTuple = property $ do
 
   let [x0'] = the (LiteralVect [(s0 ##:: F64 ##:: Double)]) $ unsafePerformIO $ TensorVect.eval (do y0 <- tensor x0; pure [y0])
 
-  x0' === x0
+  x0' ==~ x0
 
   let [x0', x1'] = the (LiteralVect [(s0 ##:: F64 ##:: Double), (s1 ##:: S32 ##:: Int32)]) $ unsafePerformIO $ TensorVect.eval (do y0 <- tensor x0; y1 <- tensor x1; pure [y0, y1])
 
-  x0' === x0
+  x0' ==~ x0
   x1' === x1
 
   let [x0', x1', x2'] = the (LiteralVect [(s0 ##:: F64 ##:: Double), (s1 ##:: S32 ##:: Int32), (s2 ##:: U64 ##:: Nat)]) $ unsafePerformIO $ TensorVect.eval (do y0 <- tensor x0; y1 <- tensor x1; y2 <- tensor x2; pure [y0, y1, y2])
 
-  x0' === x0
+  x0' ==~ x0
   x1' === x1
   x2' === x2
 

--- a/test/Unit/TestTensor.idr
+++ b/test/Unit/TestTensor.idr
@@ -447,7 +447,7 @@ group : Group
 group = MkGroup "Tensor" $ [
       ("eval . tensor", tensorThenEval)
     , ("eval multiple tensors", evalTuple)
-    , ("eval multiple tensors for non-trivial graph", evalTuple)
+    , ("eval multiple tensors for non-trivial graph", evalTupleNonTrivial)
     , ("can read/write finite numeric bounds to/from XLA", canConvertAtXlaNumericBounds)
     , ("bounded non-finite", boundedNonFinite)
     , ("iota", iota)


### PR DESCRIPTION
- [ ] modify multi-tensor `eval` so that inference works at usage site
- [ ] reduce usage of list overloading to improve compilation times and error messages
- [ ] consider using built-in types over custom versions e.g. `Pair` over custom vect-like types, and a built-in right- (or left-)erased type if possible
- [ ] choose location of custom vect-like types if using them
- [ ] is `ShapeIndex` (the Idris version) constructed in the right place? Would passing a `List Nat` to the Idris XLA API work better?

I may want to change more than this